### PR TITLE
Minor grammatical fix: tranpose to transpose

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -1898,7 +1898,7 @@ var nerdamer = (function() {
         
         function transpose(mat) {
             if(isMatrix(mat)) return mat.transpose();
-            err('function tranpose expects a matrix');
+            err('function transpose expects a matrix');
         }
         
         function invert(mat) {


### PR DESCRIPTION
Just a minor grammatical fix. Error message changed from "function tranpose expects a matrix" to "function transpose expects a matrix".
